### PR TITLE
fix(0.72): 修复首次拉起微信无回调（冷启动回调丢失）

### DIFF
--- a/harmony/react_native_wechat_lib/src/main/ets/WechatLibTurboModule.ets
+++ b/harmony/react_native_wechat_lib/src/main/ets/WechatLibTurboModule.ets
@@ -59,6 +59,7 @@ export class WechatLibTurboModule extends TurboModule implements TM.WechatLibTur
   private appId: string | null = null;
   private wxEventHandler = WXEventHandler
   private static wxApi: wxopensdk.WXApi | null = null;
+  private static pendingWants: Array<Want> = [];
   private context = getContext(this) as common.UIAbilityContext;
   lastOAuth: wxopensdk.IDiffDevOAuth | null = null
   loadStatus: LoadingStatus = LoadingStatus.INIT
@@ -91,8 +92,22 @@ export class WechatLibTurboModule extends TurboModule implements TM.WechatLibTur
     this.wxEventHandler.unregisterOnWXRespCallback(name)
   }
 
+  private static flushPendingWants() {
+    if (!WechatLibTurboModule.wxApi || WechatLibTurboModule.pendingWants.length === 0) {
+      return;
+    }
+    const wants = WechatLibTurboModule.pendingWants.splice(0, WechatLibTurboModule.pendingWants.length);
+    wants.forEach((pendingWant: Want) => {
+      WechatLibTurboModule.wxApi?.handleWant(pendingWant, WXEventHandler);
+    });
+  }
+
   public static handleWant(want: Want) {
-    WechatLibTurboModule.wxApi?.handleWant(want, WXEventHandler)
+    if (!WechatLibTurboModule.wxApi) {
+      WechatLibTurboModule.pendingWants.push(want);
+      return;
+    }
+    WechatLibTurboModule.wxApi.handleWant(want, WXEventHandler)
   }
 
   /**
@@ -117,6 +132,7 @@ export class WechatLibTurboModule extends TurboModule implements TM.WechatLibTur
     try {
       this.appId = appId;
       WechatLibTurboModule.wxApi = wxopensdk.WXAPIFactory.createWXAPI(appId);
+      WechatLibTurboModule.flushPendingWants();
       callback(null, true)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

本 PR 修复 Harmony 端 `react-native-wechat-lib` 在**首次冷启动拉起微信后无回调**的问题。  
Fixes #<issue-id>（请替换为实际 issue 编号）

## Motivation / Root Cause
在冷启动场景中，微信回调 `want` 可能先到达 `EntryAbility.onCreate/onNewWant`，但此时 `registerApp` 还未执行，`WechatLibTurboModule.wxApi` 尚未初始化。  
原逻辑中 `handleWant` 使用可选链直接调用，`wxApi == null` 时会直接返回，导致首个回调丢失。

## What changed
文件：
- `harmony/react_native_wechat_lib/src/main/ets/WechatLibTurboModule.ets`

主要改动：
1. 新增 `pendingWants: Array<Want>`，用于缓存 `wxApi` 初始化前收到的回调。
2. 新增 `flushPendingWants()`，在 `wxApi` 初始化后回放缓存回调。
3. 修改 `handleWant(want)`：
   - `wxApi` 未初始化：先入队再返回。
   - `wxApi` 已初始化：立即分发。
4. 修改 `registerApp(...)`：
   - `createWXAPI(appId)` 后调用 `flushPendingWants()`。

## Impact scope
仅影响 Harmony 端 WeChat 回调时序处理逻辑（`handleWant/registerApp`）；  
不改变已初始化状态下的原有调用行为。

## Test Plan

手工验证步骤：

1. 安装并启动应用，确保是冷启动（可先清应用后台/重启应用）。
2. 调用微信相关能力（如 `sendAuthRequest` 或分享能力），触发拉起微信。
3. 在微信侧完成/取消后返回应用。
4. 观察 JS 层回调（`onResp`）是否在**首次**操作时即可收到。
5. 重复执行一次（热启动场景），确认行为正常且无重复回调。

建议关注日志点：
- `EntryAbility.onCreate/onNewWant`
- `WechatLibTurboModule.handleWant`
- `WXEventHandler.onResp`

## Checklist

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [X] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
